### PR TITLE
fix: detect CI environment for playwright webServer command

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,23 @@
 import { defineConfig, devices } from '@playwright/test';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+// Detect if we have a flake.nix file (NixOS project)
+// In CI, we don't use nix, we use regular bun
+const hasFlake = existsSync(join(process.cwd(), 'flake.nix'));
+const isCI = !!process.env.CI;
+
+// Use regular bun command in CI, even if flake exists
+const webServerCommand = !isCI && hasFlake
+  ? 'nix develop --command bun run dev'  // Local NixOS development
+  : 'bun run dev';                        // CI/CD or non-Nix environments
 
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
   reporter: 'html',
   use: {
     baseURL: 'http://localhost:3000',
@@ -16,17 +28,17 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        // Use system chromium on NixOS
-        launchOptions: {
+        // Use system chromium on NixOS, downloaded chromium in CI
+        launchOptions: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ? {
           executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
-        },
+        } : {},
       },
     },
   ],
   webServer: {
-    command: 'nix develop --command bun run dev',
+    command: webServerCommand,
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
     timeout: 120000,
   },
 });


### PR DESCRIPTION
Use flake.nix detection + CI env var to choose correct command:
- Local NixOS: nix develop --command bun run dev
- GitHub Actions: bun run dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)